### PR TITLE
Include GLM library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "test/Catch2"]
 	path = test/Catch2
 	url = git@github.com:catchorg/Catch2.git
+[submodule "src/external/glm"]
+	path = src/external/glm
+	url = https://github.com/g-truc/glm.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,9 @@ if(HASH STREQUAL "")
 endif()
 message(STATUS "found hash: ${HASH}")
 
+add_subdirectory(external/glm)
+target_link_libraries(spv-interp glm::glm)
+
 add_executable(spv-run main.cpp)
 set_target_properties(spv-run PROPERTIES OUTPUT_NAME "spirv-run")
 target_compile_options(spv-run PUBLIC "-DHASH=${HASH}")

--- a/src/spv/inst-make.cpp
+++ b/src/spv/inst-make.cpp
@@ -14,6 +14,7 @@ module;
 #include <variant>
 #include <vector>
 
+#include <glm/glm.hpp>
 #include "../external/GLSL.std.450.h"
 #define SPV_ENABLE_UTILITY_CODE 1
 #include "../external/spirv.hpp"

--- a/src/spv/inst-make.cpp
+++ b/src/spv/inst-make.cpp
@@ -822,6 +822,27 @@ bool Instruction::makeResult(
             err << " and " << osize << ".";
             throw std::runtime_error(err.str());
         }
+
+        // TODO: will remove because GLM probably not be worth it here. It's here to make sure GLM works.
+        if (size == 4) {
+            // 4-D vector
+            glm::vec4 a(
+                (*static_cast<const Primitive*>((*arr[0])[0])).data.fp32, 
+                (*static_cast<const Primitive*>((*arr[0])[1])).data.fp32, 
+                (*static_cast<const Primitive*>((*arr[0])[2])).data.fp32, 
+                (*static_cast<const Primitive*>((*arr[0])[3])).data.fp32
+            );
+            glm::vec4 b(
+                (*static_cast<const Primitive*>((*arr[1])[0])).data.fp32, 
+                (*static_cast<const Primitive*>((*arr[1])[1])).data.fp32, 
+                (*static_cast<const Primitive*>((*arr[1])[2])).data.fp32, 
+                (*static_cast<const Primitive*>((*arr[1])[3])).data.fp32
+            );
+            float result = glm::dot(a, b);
+            data[result_at].redefine(new Primitive(result));
+            break;
+        }
+
         float total = 0;
         for (unsigned i = 0; i < size; ++i) {
             const Primitive& n0 = *static_cast<const Primitive*>((*arr[0])[i]);


### PR DESCRIPTION
Included the GLM library via git submodules into the interpreter for future use. 

To make sure the library works, the `OpDot` instruction in `inst-make.cpp` has been modified to use GLM for 4-D vectors, and it was tested with the func-dot example from the examples directory.