### PR TITLE
Re-add missing includes

### DIFF
--- a/src/values/type.hpp
+++ b/src/values/type.hpp
@@ -8,6 +8,7 @@
 
 #include <algorithm> // for min
 #include <cassert>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Different platforms require different headers (some platforms allow for headers to be implicit). Fix the headers which were erroneously removed.