### PR TITLE
Warn for undefined behavior

### DIFF
--- a/src/front/console.cxx
+++ b/src/front/console.cxx
@@ -18,6 +18,8 @@ module;
 
 export module front.console;
 
+export bool suppress_warnings = false;
+
 export class Console {
     unsigned width;
     unsigned headerWidth;
@@ -84,5 +86,28 @@ public:
         std::cout << msg << std::endl;
         if (crunched)  // print an extra newline to separate entries
             std::cout << std::endl;
+    }
+
+    static void warn(std::string msg) {
+        if (suppress_warnings)
+            return;
+
+#if defined(WIN32) || defined(_WIN32)
+        HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+        constexpr int RED_ON_BLACK = 12;
+        FlushConsoleInputBuffer(hConsole);
+        SetConsoleTextAttribute(hConsole, RED_ON_BLACK);
+#else
+        std::cout << "\e[0;31m";
+#endif
+
+        std::cout << "[Warning] " << msg << std::endl;
+
+#if defined(WIN32) || defined(_WIN32)
+        constexpr int DEFAULT = 7;
+        SetConsoleTextAttribute(hConsole, DEFAULT);
+#else
+        std::cout << "\e[0m";
+#endif
     }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,6 +197,8 @@ int main(int argc, char* argv[]) {
     parser.addOption(&out_arg, "out", "Specify a file to output to. By default, output prints to stdout.", "o");
     ArgParse::Flag verbose;
     parser.addOption(&verbose, "print", "Enable verbose printing.", "p");
+    ArgParse::Flag quiet;
+    parser.addOption(&quiet, "quiet", "Suppress all runtime warnings.", "q");
     ArgParse::Flag rt_template;
     parser.addOption(
         &rt_template,
@@ -278,6 +280,7 @@ int main(int argc, char* argv[]) {
         verbose.enabled = true;
     if ((generate.enabled || rt_template.enabled) && !template_arg.hasValue())
         template_arg.setValue("-");
+    suppress_warnings = quiet.enabled;
 
     ValueFormat* format = determine_format(format_arg.getValue(), nullptr, true);
     if (format == nullptr) {


### PR DESCRIPTION
Print a visible warning when undefined behavior is encountered. It is decidedly overkill to crash when something undefined happens, but as an intended "correct" reference, the user should be alerted in such a circumstance.

Add a new command line flag, "quiet", which will suppress all runtime warnings.