### PR TITLE
Localize Includes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: 'true'
 

--- a/src/spv/inst-exec.cpp
+++ b/src/spv/inst-exec.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "../front/console.hpp"
+#include "../util/fpconvert.hpp"
 #include "../util/ternary.hpp"
 #include "../values/aggregate.hpp"
 #include "../values/coop-matrix.hpp"

--- a/src/spv/inst-make.cpp
+++ b/src/spv/inst-make.cpp
@@ -16,7 +16,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <variant>
+#include <variant> // for std::get
 #include <vector>
 
 #include "../../external/GLSL.std.450.h"
@@ -40,7 +40,6 @@
 #include "../values/value.hpp"
 #include "data/data.hpp"
 #include "data/manager.hpp"
-#include "frame.hpp"
 #include "token.hpp"
 
 Value* construct_from_vec(const std::vector<Primitive>& vec, const Type* res_type) {

--- a/src/spv/inst-read.cpp
+++ b/src/spv/inst-read.cpp
@@ -5,7 +5,7 @@
  */
 #include "instruction.hpp"
 
-#include <bit>
+#include <bit> // for std::bit_cast
 #include <cassert>
 #include <cstdint>
 #include <sstream>
@@ -13,7 +13,6 @@
 #include <string>
 #include <vector>
 
-#include "frame.hpp"
 #include "token.hpp"
 
 bool parseString(const std::vector<uint32_t>& words, unsigned& i, std::stringstream& str) {

--- a/src/spv/instruction.cpp
+++ b/src/spv/instruction.cpp
@@ -8,7 +8,7 @@
 #include <sstream>
 #include <stdexcept>
 
-Instruction::Extension Instruction::extensionFromString(const std::string& ext_name) const {
+Extension Instruction::extensionFromString(const std::string& ext_name) const {
     // Contains only implemented extensions
     static const std::vector<std::string> supported_ext {
         "GLSL.std.450",
@@ -21,11 +21,11 @@ Instruction::Extension Instruction::extensionFromString(const std::string& ext_n
 
     for (unsigned i = 0; i < supported_ext.size(); ++i) {
         if (ext_name == supported_ext[i])
-            return static_cast<Instruction::Extension>(i);
+            return static_cast<Extension>(i);
     }
     if (ext_name.find("NonSemantic.ClspvReflection.", 0) == 0)
-        return Instruction::Extension::NONSEMANTIC_CLSPV_REFLECTION;
-    return Instruction::Extension::INVALID;
+        return Extension::NONSEMANTIC_CLSPV_REFLECTION;
+    return Extension::INVALID;
 }
 
 unsigned Instruction::checkRef(unsigned idx, unsigned len) const noexcept(false) {

--- a/src/spv/instruction.hpp
+++ b/src/spv/instruction.hpp
@@ -21,6 +21,16 @@
 #include "frame.hpp"
 #include "token.hpp"
 
+enum class Extension : unsigned {
+    GLSL_STD_450 = 0,
+    SPV_KHR_RAY_TRACING,
+    SPV_KHR_RAY_QUERY,
+    NONSEMANTIC_SHADER_DEBUG_INFO,
+    NONSEMANTIC_DEBUG_PRINTF,
+    NONSEMANTIC_CLSPV_REFLECTION,
+    INVALID,
+};
+
 class Instruction {
     spv::Op opcode;
     bool hasResult;
@@ -28,16 +38,6 @@ class Instruction {
 protected:
     // Fields protected for the sake of testing
     std::vector<Token> operands;
-
-    enum class Extension : unsigned {
-        GLSL_STD_450 = 0,
-        SPV_KHR_RAY_TRACING,
-        SPV_KHR_RAY_QUERY,
-        NONSEMANTIC_SHADER_DEBUG_INFO,
-        NONSEMANTIC_DEBUG_PRINTF,
-        NONSEMANTIC_CLSPV_REFLECTION,
-        INVALID,
-    };
 private:
 
     /// @brief Find if a given extension is supported by the interpreter

--- a/src/spv/program.cpp
+++ b/src/spv/program.cpp
@@ -5,10 +5,13 @@
  */
 #include "program.hpp"
 
+#include <cassert>
 #include <iostream>
 #include <set>
+#include <tuple>
 #include <stdexcept>
 
+#include "var-compare.hpp"
 #include "../front/debug.hpp"
 
 bool Program::ProgramLoader::determineEndian() {

--- a/src/spv/program.hpp
+++ b/src/spv/program.hpp
@@ -6,29 +6,19 @@
 #ifndef SPV_PROGRAM_HPP
 #define SPV_PROGRAM_HPP
 
-#include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <vector>
 
 #include "../util/spirv.hpp"
-#include "glm/ext.hpp"
 
 #include "../format/parse.hpp"
-#include "../values/aggregate.hpp"
-#include "../values/primitive.hpp"
-#include "../values/raytrace/accel-struct.hpp"
 #include "../values/raytrace/shader-binding-table.hpp"
-#include "../values/raytrace/trace.hpp"
-#include "../values/type.hpp"
-#include "../values/value.hpp"
-#include "data/data.hpp"
+#include "../values/value.hpp" // ValueMap
 #include "data/manager.hpp"
 #include "frame.hpp"
 #include "inst-list.hpp"
 #include "instruction.hpp"
 #include "ray-substage.hpp"
-#include "var-compare.hpp"
 
 class Program {
     InstList insts;

--- a/src/spv/ray-substage.cpp
+++ b/src/spv/ray-substage.cpp
@@ -5,6 +5,10 @@
  */
 #include "ray-substage.hpp"
 
+#include "../util/spirv.hpp"
+#include "../values/aggregate.hpp"
+#include "../values/primitive.hpp"
+
 void copy_into(Value* into, std::vector<Primitive>& src) {
     Array& into_arr = static_cast<Array&>(*into);
     for (unsigned i = 0; i < src.size(); ++i)

--- a/src/spv/ray-substage.hpp
+++ b/src/spv/ray-substage.hpp
@@ -9,12 +9,8 @@
 #include <cassert>
 #include <vector>
 
-#include "../util/spirv.hpp"
-#include "../values/aggregate.hpp"
-#include "../values/primitive.hpp"
 #include "../values/raytrace/accel-struct.hpp"
 #include "../values/raytrace/node.hpp"
-#include "../values/raytrace/trace.hpp"
 #include "../values/value.hpp"
 #include "data/data.hpp"
 #include "data/manager.hpp"

--- a/src/values/primitive.cpp
+++ b/src/values/primitive.cpp
@@ -6,7 +6,9 @@
 #include "primitive.hpp"
 
 #include <bit>  // bit_cast, countl_zero
+#include <stdexcept>
 
+#include "../util/compare.hpp"
 #include "../util/fpconvert.hpp"
 
 void Primitive::copyFrom(const Value& new_val) noexcept(false) {

--- a/src/values/primitive.hpp
+++ b/src/values/primitive.hpp
@@ -9,10 +9,7 @@
 #include <cassert>
 #include <cmath>  // for nanf
 #include <cstdint>  // for uint32_t and int32_t
-#include <stdexcept>
 
-#include "../util/compare.hpp"
-#include "../util/fpconvert.hpp"
 #include "type.hpp"
 #include "value.hpp"
 

--- a/src/values/raytrace/accel-struct.hpp
+++ b/src/values/raytrace/accel-struct.hpp
@@ -7,7 +7,7 @@
 #define VALUES_RAYTRACE_ACCELSTRUCT_HPP
 
 #include <cmath>
-#include <limits>
+#include <limits> // std::numeric_limits
 #include <string>
 #include <vector>
 

--- a/src/values/raytrace/ray-query.hpp
+++ b/src/values/raytrace/ray-query.hpp
@@ -16,7 +16,6 @@
 #include "../aggregate.hpp"
 #include "../primitive.hpp"
 #include "../raytrace/accel-struct.hpp"
-#include "../string.hpp"
 #include "../type.hpp"
 #include "../value.hpp"
 

--- a/test/spv/instruction-test.cpp
+++ b/test/spv/instruction-test.cpp
@@ -26,8 +26,6 @@ struct DummyInstruction : public Instruction {
             operands.emplace_back(0);
         operands[idx] = token;
     }
-
-    using Instruction::Extension;
 };
 
 template<typename T>
@@ -132,7 +130,7 @@ TEST_CASE("GLSLstd450PackHalf2x16", "[instruction]") {
 
     inst.setOperand(0, make_ref(data, u32));
     inst.setOperand(1, Token(Token::Type::REF, result_id));
-    inst.setOperand(2, make_ref(data, new Primitive(static_cast<uint64_t>(DummyInstruction::Extension::GLSL_STD_450))));
+    inst.setOperand(2, make_ref(data, new Primitive(static_cast<uint64_t>(Extension::GLSL_STD_450))));
     inst.setOperand(3, Token(Token::Type::CONST, GLSLstd450PackHalf2x16)); // ext opcode
 
     auto check_pack = [&](double lo, double hi, uint32_t expected) {


### PR DESCRIPTION
Localize includes by moving indirect includes from header files to the
implementation. Also move Instruction's Extension enum to the global
namespace to resolve a Windows error.

Update the action runner to avoid the old Node version warning on
GitHub.